### PR TITLE
Add missing dependency on the version script.

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -31,6 +31,10 @@ target_link_options(app
     -flto
     -Wl,--version-script,${CMAKE_SOURCE_DIR}/libapp.map.txt
 )
+set_target_properties(app
+  PROPERTIES
+    LINK_DEPENDS ${CMAKE_SOURCE_DIR}/libapp.map.txt
+)
 
 add_library(app_tests SHARED app_test.cpp)
 target_link_libraries(app_tests


### PR DESCRIPTION
CMake doesn't know what that flag means, so it can't do this automatically.