### PR TITLE
target_include_directories do not propagate for OBJECT targets

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -44,3 +44,7 @@ target_link_libraries(app_tests
     googletest::gmock
     junit-gtest::junit-gtest
 )
+target_include_directories(app_tests
+  PRIVATE
+    $<TARGET_PROPERTY:app_impl,INTERFACE_INCLUDE_DIRECTORIES>
+)


### PR DESCRIPTION
make sure test library has access to those without using local paths